### PR TITLE
Fixed TypeError when changing brightness

### DIFF
--- a/src/usr/share/tuxedo-backlight-control/backlight.py
+++ b/src/usr/share/tuxedo-backlight-control/backlight.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         if arg > 255 or arg < 0:
             exit(error_invalid_brightness(arg))
 
-        backlight.brightness = arg
+        backlight.brightness = str(arg)
     elif len(argv) == 3 and cmd == "color" and arg in colorlist:
         backlight.state = 1
         backlight.set_single_color(arg)


### PR DESCRIPTION
I was getting Type errors when attempting to set the brightness from the cli. This commit should fix that. I have tested it on Fedora 35 on an Aura 15 Gen 1 Laptop.